### PR TITLE
Add support for PingFederate clustering using DNS_PING

### DIFF
--- a/pf-dns-ping-clustering/pingfederate/instance/README.md
+++ b/pf-dns-ping-clustering/pingfederate/instance/README.md
@@ -1,0 +1,6 @@
+# Purpose
+This directory contains the data that is required to cluster PingFederate using the DNS_PING
+cluster discovery mechanism, requires PingFederate Version 10 or later.
+
+This code can be merged into baseline/pingfederate once PF 10 goes GA, ther is an 
+incompatible change to hivemodule.xml which will break PF 9.3 & below.

--- a/pf-dns-ping-clustering/pingfederate/instance/server/default/conf/META-INF/hivemodule.xml
+++ b/pf-dns-ping-clustering/pingfederate/instance/server/default/conf/META-INF/hivemodule.xml
@@ -1,0 +1,175 @@
+<module id="com.pingfederatehive" version="1.0.1">
+
+    <!-- Runtime state managment services -->
+    <service-point id="ArtifactStore" interface="org.sourceid.saml20.service.ArtifactPersistenceService">
+      <create-instance class="org.sourceid.saml20.service.impl.proxy.ArtifactPersistenceSvcProxy" model="primitive"/>
+    </service-point>
+
+    <service-point id="AssertionReplayPreventionService" interface="org.sourceid.saml20.service.AssertionReplayPreventionService">
+      <create-instance class="org.sourceid.saml20.service.impl.proxy.AssertionReplayPreventionSvcProxy" model="primitive"/>
+    </service-point>
+
+    <service-point id="IdpSessionReqistry" interface="org.sourceid.saml20.service.IdpSessionRegistry">
+      <create-instance class="org.sourceid.saml20.service.impl.proxy.IdpSessionRegistryProxy" model="primitive"/>
+    </service-point>
+
+    <service-point id="SpSessionReqistry" interface="org.sourceid.saml20.service.SpSessionRegistry">
+      <create-instance class="org.sourceid.saml20.service.impl.proxy.SpSessionRegistryProxy" model="primitive"/>
+    </service-point>
+
+    <service-point id="InterRequestStateMgmt" interface="org.sourceid.saml20.service.InterRequestStateMgmt">
+      <!--
+        Supported classes are
+            org.sourceid.saml20.service.impl.proxy.InterRequestStateMgmtProxy
+            org.sourceid.saml20.service.impl.grouprpc.InterRequestStateMgmtGroupRpcImpl
+            org.sourceid.saml20.service.impl.localmemory.InterReqStateMgmtMapImpl
+      -->
+      <create-instance class="org.sourceid.saml20.service.impl.proxy.InterRequestStateMgmtProxy" model="primitive"/>
+    </service-point>
+
+    <service-point id="SessionRevocationService" interface="org.sourceid.saml20.service.SessionRevocationService">
+      <create-instance class="org.sourceid.saml20.service.impl.proxy.SessionRevocationServiceProxy" model="primitive"/>
+    </service-point>
+
+    <service-point id="NodeIndexRegistry" interface="org.sourceid.saml20.service.util.NodeIndexRegistry">
+      <create-instance class="org.sourceid.saml20.service.impl.grouprpc.NodeIndexRegistryGroupRpcImpl" model="primitive"/>
+    </service-point>
+
+    <service-point id="AccountLockingService" interface="org.sourceid.saml20.service.impl.proxy.LockingServiceFactory">
+      <!--
+        Supported classes are
+            org.sourceid.saml20.service.impl.proxy.AccountLockingServiceProxy
+            org.sourceid.saml20.service.impl.grouprpc.AccountLockingServiceGroupRpcImpl (should only be used for engine nodes, not the admin console)
+            org.sourceid.saml20.service.impl.localmemory.AccountLockingServiceInMemoryImpl
+      -->
+      <create-instance class="org.sourceid.saml20.service.impl.proxy.AccountLockingServiceProxy" model="primitive"/>
+    </service-point>
+
+    <!-- Crypto provider -->
+    <service-point id="JCEManager" interface="com.pingidentity.crypto.JCEManager">
+         <invoke-factory>
+             <!--
+                 Supported classes are
+                     com.pingidentity.crypto.SunJCEManager     : Use this service-point if you are using default certificate storage
+                     com.pingidentity.crypto.LunaJCEManager6   : Use this service-point element if you are using the SafeNet Luna SA HSM 6.x to store certs
+                     com.pingidentity.crypto.NcipherJCEManager : Use this service-point element if you are using the Thales nShield Connect HSM to store certs
+             -->
+             <construct class="com.pingidentity.crypto.SunJCEManager"/>
+         </invoke-factory>
+     </service-point>
+
+    <service-point id="CertificateService" interface="com.pingidentity.crypto.CertificateService">
+         <invoke-factory>
+             <!--
+                 Supported classes are
+                     com.pingidentity.crypto.CertificateServiceImpl        : Use this service-point if you are using default certificate storage
+                     com.pingidentity.crypto.LunaCertificateServiceImpl6   : Use this service-point element if you are using the SafeNet Luna SA HSM 6.x to store certs
+                     com.pingidentity.crypto.NcipherCertificateServiceImpl : Use this service-point element if you are using the Thales nShield Connect HSM to store certs
+             -->
+             <construct class="com.pingidentity.crypto.CertificateServiceImpl"/>
+         </invoke-factory>
+     </service-point>
+
+    <!-- Service/adapter for storage of account linking -->
+    <service-point id="AccountLinkingService" interface="org.sourceid.saml20.service.AccountLinkingService">
+        <!--
+                Supported classes are
+                        org.sourceid.saml20.service.impl.AccountLinkingServiceDBImpl    : Use this service-point for a database implementation
+                        org.sourceid.saml20.service.impl.AccountLinkingServiceLDAPImpl  : Use this service-point for an LDAP implementation
+        -->
+        <create-instance class="org.sourceid.saml20.service.impl.AccountLinkingServiceLDAPImpl"/>
+    </service-point>
+
+    <!-- Service for storage of access grants -->
+    <service-point id="AccessGrantManager" interface="com.pingidentity.sdk.accessgrant.AccessGrantManager">
+        <!--
+                Supported classes are
+                        org.sourceid.oauth20.token.AccessGrantManagerJdbcImpl               : Use this service-point for a Jdbc implementation
+                        org.sourceid.oauth20.token.AccessGrantManagerLDAPADImpl             : Use this service-point for a Microsoft Active Directory implementation
+                        org.sourceid.oauth20.token.AccessGrantManagerLDAPOracleImpl         : Use this service-point for a Oracle Directory Server Enterprise Edition implementation
+                        org.sourceid.oauth20.token.AccessGrantManagerLDAPPingDirectoryImpl  : Use this service-point for a PingDirectory implementation
+        -->
+        <create-instance class="org.sourceid.oauth20.token.AccessGrantManagerLDAPPingDirectoryImpl"/>
+    </service-point>
+
+    <!-- Service/adapter for creating pseudonym name ids -->
+    <service-point id="PseudonymService" interface="org.sourceid.saml20.service.PseudonymService">
+        <create-instance class="org.sourceid.saml20.service.impl.PseudonymServiceSha1Impl" model="primitive"/>
+    </service-point>
+
+    <!-- URL matching service for target apps/adapter selection -->
+    <service-point id="UrlMatchingService" interface="org.sourceid.saml20.profiles.sp.UrlMatchingService">
+        <invoke-factory>
+            <construct class="org.sourceid.saml20.profiles.sp.UrlMatchingServiceOneStarImpl"/>
+        </invoke-factory>
+    </service-point>
+
+    <!-- a service to do certificate revocation checking - change to RevocationCheckerNullImpl to turn off -->
+    <service-point id="RevocationChecker" interface="com.pingidentity.crypto.RevocationChecker">
+        <invoke-factory>
+            <construct class="com.pingidentity.crypto.RevocationCheckerImpl"/>
+            <!--<construct class="com.pingidentity.crypto.RevocationCheckerNullImpl"/>-->
+        </invoke-factory>
+    </service-point>
+
+    <service-point id="Halter" interface="org.sourceid.saml20.util.SystemUtil$Halter">
+        <create-instance class="org.sourceid.saml20.util.SystemUtil$RealHalter"/>
+    </service-point>
+
+    <!-- Locale override service -->
+    <service-point id="LocaleOverrideService" interface="com.pingidentity.sdk.locale.LocaleOverrideService">
+        <invoke-factory>
+            <construct class="com.pingidentity.locale.LocaleOverrideServiceImpl"/>
+        </invoke-factory>
+    </service-point>
+
+    <!-- Service for using custom OAuth client storage implementation. -->
+    <service-point id="ClientStorageManager" interface="com.pingidentity.sdk.oauth20.ClientStorageManagerV2">
+        <invoke-factory>
+            <!--
+                Provide the class name for the custom OAuth client storage implementation.
+            -->
+            <construct class="org.sourceid.oauth20.domain.NoOpClientStorageManager"/>
+        </invoke-factory>
+    </service-point>
+
+    <!-- Service for storing OAuth client configuration. -->
+    <service-point id="ClientManager" interface="org.sourceid.oauth20.domain.ClientManager">
+        <invoke-factory>
+            <!--
+                Supported classes are
+                        org.sourceid.oauth20.domain.ClientManagerXmlFileImpl            : Use this service-point for a XML implementation.
+                        org.sourceid.oauth20.domain.ClientManagerJdbcImpl               : Use this service-point for a Jdbc implementation.
+                        org.sourceid.oauth20.domain.ClientManagerLdapImpl               : Use this service-point for a LDAP implementation.
+                        org.sourceid.oauth20.domain.ClientManagerGenericImpl            : Use this service-point if you have specified a custom ClientStorageManager implementation above.
+            -->
+            <construct class="org.sourceid.oauth20.domain.ClientManagerLdapImpl"/>
+        </invoke-factory>
+    </service-point>
+
+    <!-- Service for storing Authentication Sessions. -->
+    <service-point id="SessionStorageManager" interface="org.sourceid.saml20.service.session.data.SessionStorageManager">
+        <invoke-factory>
+            <!--
+                Supported classes are
+                        org.sourceid.saml20.service.session.data.impl.SessionStorageManagerJdbcImpl : Use this service-point for a Jdbc implementation.
+                        org.sourceid.saml20.service.session.data.impl.SessionStorageManagerLdapImpl : Use this service-point for a LDAP implementation.
+            -->
+            <construct class="org.sourceid.saml20.service.session.data.impl.SessionStorageManagerLdapImpl"/>
+        </invoke-factory>
+    </service-point>
+
+    <!--
+        Service for encrypting/decrypting PingFederate's master key file (pf.jwk). The default
+        implementation does no operation and hence the keys are stored in plain text. Any custom
+        implementation can be created and referred to here. See the PingFederate SDK's
+        com.pingidentity.sdk.key.MasterKeyEncryptor interface for more info.
+     -->
+    <service-point id="MasterKeyEncryptor" interface="com.pingidentity.sdk.key.MasterKeyEncryptor">
+        <create-instance class="com.pingidentity.crypto.jwk.NoOpMasterKeyEncryptor"/>
+	  </service-point>
+	  <!-- Service/adapter for creating pairwise pseudonymous identifiers -->
+    <service-point id="PairwisePseudonymService" interface="org.sourceid.openid.connect.service.PairwisePseudonymService">
+        <create-instance class="org.sourceid.openid.connect.service.impl.PairwisePseudonymServiceAESImpl" model="primitive"/>
+    </service-point>
+</module>

--- a/pf-dns-ping-clustering/pingfederate/instance/server/default/conf/tcp.xml.subst
+++ b/pf-dns-ping-clustering/pingfederate/instance/server/default/conf/tcp.xml.subst
@@ -1,0 +1,132 @@
+<config>
+    <TCP_NIO2
+            recv_buf_size="5M"
+            send_buf_size="5M"
+            max_bundle_size="64K"
+            bind_port="${_DOLLAR_}{pf.cluster.bind.port}"
+            sock_conn_timeout="300"
+            max_send_buffers="1000"
+
+            enable_diagnostics="${_DOLLAR_}{pf.cluster.diagnostics.enabled}"
+            diagnostics_addr="${_DOLLAR_}{pf.cluster.diagnostics.addr}"
+            diagnostics_port="${_DOLLAR_}{pf.cluster.diagnostics.port}"
+
+            thread_pool.enabled="true"
+            thread_pool.min_threads="4"
+            thread_pool.max_threads="40"
+            thread_pool.keep_alive_time="8000"
+
+            logical_addr_cache_expiration="1000"
+            logical_addr_cache_reaper_interval="10000"
+
+            bind_addr="${_DOLLAR_}{pf.cluster.bind.address}"
+            log_discard_msgs="false"/>
+	<!--
+   <TCPPING initial_hosts="${_DOLLAR_}{pf.cluster.tcp.discovery.initial.hosts}"
+            return_entire_cache="true"
+            port_range="0"/>
+	-->
+    <!-- To enable discovery using the AWS SDK and a file stored in S3, comment out TCPPING, and uncomment the
+         section below. This is the recommended dynamic discovery mechanism when running in AWS but not using Kubernetes.
+         See https://github.com/jgroups-extras/native-s3-ping for further information on the available settings. -->
+    <!--
+    <org.jgroups.aws.s3.NATIVE_S3_PING
+            region_name="us-east-1"
+            bucket_name="[...]"
+            remove_all_data_on_view_change="true"
+            write_data_on_find="true"/>
+    -->
+
+    <!-- To enable discovery using a file stored in S3, comment out TCPPING, and uncomment the section below.
+         Passwords and keys may be encrypted using PingFederate's obfuscate utility.
+         This is the recommended dynamic discovery mechanism when not running in AWS and not using Kubernetes.
+         See JGroups documentation on S3_PING for further information on the available settings. -->
+    <!--
+    <S3_PING location="[bucket name]"
+             access_key="[...]"
+             secret_access_key="[...]"
+             remove_all_data_on_view_change="true"
+             write_data_on_find="true"/>
+    -->
+
+    <!-- To enable discovery using DNS records, comment out TCPPING, and uncomment the section below.
+         This is the recommended dynamic discovery mechanism when using Kubernetes.
+         See JGroups documentation on DNS_PING for further information on the available settings. -->
+
+
+    <dns.DNS_PING
+		 dns_query="${PF_DNS_PING_CLUSTER}.${PF_DNS_PING_NAMESPACE}.svc.cluster.local" />
+
+
+    <!-- To enable discovery of EC2 instances in AWS dynamically, comment out TCPPING, and uncomment the section below.
+         This is an alternative to NATIVE_S3_PING when running on EC2 and not using container technology.
+
+         This plugin requires the ec2:Describe permission to be enabled in either the IAM settings for this EC2
+         instance or associated with the access_key configured below.
+
+         Tags, Filters, or a combination of the two can be used to identify the systems in EC2 that should be a
+         part of the PingFederate cluster.
+
+         port_number - The port number that PingFederate listens on for cluster communication. This should normally be left as
+                       ${_DOLLAR_}{pf.cluster.bind.port}.
+         port_range  - (OPTIONAL) PingFederate may probe additional ports when attempting to connect to other
+                       nodes. Specify the number of additional ports beyond port_number to probe. The default is 0.
+         regions     - (OPTIONAL) A comma separated list of EC2 regions in which discovery should be attempted. If no regions
+                       are specified, only nodes in the same region as this node will be discovered. If nodes are running in
+                       multiple regions, it is recommended to list all regions in this field.
+         tags        - (OPTIONAL) A comma separated list of EC2 tags to use to compare to other nodes found in EC2. For a node
+                       to be considered, all tags need to match.
+                       Example: tags="TAG1,TAG2" - Nodes that have the same value as this node for BOTH tags will be considered
+                       for joining the cluster.
+         filters     - (OPTIONAL) A semi-colon separated list of key value pairs to match on. Please refer to the EC2 documentation
+                       to see what attributes are available for filtering.
+                       Example: filters="FILTER1=VALUE1,VALUE2;FILTER2=VALUE3" - Any nodes that match at least one
+                       value for each filter will be considered for joining the cluster.
+         access_key  - (OPTIONAL) The access_key to use to query EC2 to get instance information. If omitted, AWS_PING
+                       will use the IAM settings configured for this EC2 instance. May be encrypted using PingFederate's
+                       obfuscate utility.
+         secret_key  - (OPTIONAL) Required if an access_key is provided. The secret key associated with the access_key.
+                       If omitted, AWS_PING will use the IAM settings configured for this EC2 instance. May be encrypted
+                       using PingFederate's obfuscate utility.
+    -->
+    <!--
+    <com.pingidentity.aws.AWS_PING
+            port_number="${_DOLLAR_}{pf.cluster.bind.port}"
+            port_range="0"
+            regions=""
+            tags=""
+            filters=""
+            access_key=""
+            secret_key=""
+            log_aws_error_messages="true"/>
+    -->
+
+    <!-- To enable discovery using a file stored in Swift, comment out TCPPING, and uncomment the section below.
+         Passwords and keys may be encrypted using PingFederate's obfuscate utility.
+         See JGroups documentation on SWIFT_PING for further information on the available settings. -->
+    <!--
+    <SWIFT_PING
+             auth_type="keystone_v_2_0"
+             auth_url="[...]/v2.0/tokens"
+             username="[...]"
+             password="[...]"
+             tenant="[...]"
+             container="[...]"
+             remove_all_data_on_view_change="true"/>
+    -->
+
+    <MERGE3 min_interval="30000" max_interval="60000" />
+    <FD_SOCK start_port="${_DOLLAR_}{pf.cluster.failure.detection.bind.port}" bind_addr="${_DOLLAR_}{pf.cluster.bind.address}"/>
+    <FD timeout="10000" max_tries="5"/>
+    <VERIFY_SUSPECT timeout="1500"/>
+    <BARRIER/>
+    ${_DOLLAR_}{ENCRYPT_TAG}
+    <pbcast.NAKACK2
+                   use_mcast_xmit="false"
+                   discard_delivered_msgs="false"/>
+    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"  max_bytes="400000"/>
+    <pbcast.GMS print_local_addr="true" join_timeout="3000" view_ack_collection_timeout="5000"/>
+    <FRAG2 frag_size="60000"/>
+    <pbcast.STATE_TRANSFER/>
+</config>
+


### PR DESCRIPTION
Add support for PingFederate clustering using the DNS_PING cluster discovery mechanism, this is only supported for PF v10+. Until PF10 goes GA this needs to be a layered profile as there is an incompatible change to hivemodule.xml that will break PF 9.3 and earlier versions.