### PR TITLE
PingCentral: Add Security Headers to props file for PingCentral 1.4

### DIFF
--- a/baseline/pingcentral/external-mysql-db/instance/conf/application.properties.subst
+++ b/baseline/pingcentral/external-mysql-db/instance/conf/application.properties.subst
@@ -51,3 +51,5 @@ server.ssl.https.verify-hostname=${PING_CENTRAL_VERIFY_HOSTNAME}
 # The name of the claim which identifies the username as determined by the Authorization Server
 #pingcentral.sso.oidc.oauth-username-claim-name=Username
 logging.level.com.pingidentity=${PING_CENTRAL_LOG_LEVEL}
+# Security headers to include in API responses
+#pingcentral.admin.api-security-headers=Strict-Transport-Security,Content-Security-Policy,Feature-Policy


### PR DESCRIPTION
PingCentral 1.4 includes new security headers.  These are enabled by default, but can also be switched on/off via the properties file. I added these headers to the properties file commented out to make it more obvious to the customer that these can be edited if need be.