### PR TITLE
STAGING-12310: Fix Baseline PingDirectory LDIF File Defect

### DIFF
--- a/baseline/pingdirectory/pd.profile/ldif/userRoot/30-OAuthClients.ldif
+++ b/baseline/pingdirectory/pd.profile/ldif/userRoot/30-OAuthClients.ldif
@@ -445,7 +445,7 @@ pf-oauth-client-jwks: eyAgICAia2V5cyI6WyAgICAgICB7ICAgICAgICAgICJrdHkiOiJSU0EiLC
 pf-oauth-client-enforce-replay-prevention: FALSE
 pf-oauth-client-bypass-approval-page: FALSE
 
-dn: pf-oauth-client-id=dadmin,ou=oauthClients,dc=example,dc=com
+dn: pf-oauth-client-id=dadmin,ou=oauthClients,${USER_BASE_DN}
 objectClass: pf-oauth-client
 pf-oauth-client-name: dadmin
 pf-oauth-client-last-modified: 1555106380376
@@ -478,7 +478,7 @@ pf-oauth-client-authn-type: NONE
 pf-oauth-client-enforce-replay-prevention: FALSE
 pf-oauth-client-bypass-approval-page: TRUE
 
-dn: pf-oauth-client-id=PingDirectory,ou=oauthClients,dc=example,dc=com
+dn: pf-oauth-client-id=PingDirectory,ou=oauthClients,${USER_BASE_DN}
 objectClass: pf-oauth-client
 pf-oauth-client-name: PingDirectory
 pf-oauth-client-last-modified: 1555105760814


### PR DESCRIPTION
- Update two entries in 30-OAuthClients.ldif to use
`${USER_BASE_DN}` instead of `dc=example,dc=com` for the
dadmin and PingDirectory OAuth clients.

Closes STAGING-12310