### PR TITLE
Gdo 786 tls

### DIFF
--- a/baseline/pingdirectoryproxy/env_vars
+++ b/baseline/pingdirectoryproxy/env_vars
@@ -1,0 +1,13 @@
+#
+# NOTICE: the values in this file will override the values provided to the container
+#
+#         if that is not the intent, and a default value should be set instead
+#         use a syntax like:
+#         export MY_ENVIRONMENT_VARIABLE_0=${MY_ENVIRONMENT_VARIABLE_0:=myDefaultValue}
+#                or
+#         export MY_ENVIRONMENT_VARIABLE_1=${MY_ENVIRONMENT_VARIABLE_1:-wasNotSetElsewhere}
+# The location MUST be provided
+export LOCATION=${LOCATION:-Docker}
+
+export PD_ENGINE_PRIVATE_HOSTNAME=${PD_ENGINE_PRIVATE_HOSTNAME:=pingdirectory}
+export PD_ENGINE_PRIVATE_PORT_LDAPS=${PD_ENGINE_PRIVATE_PORT_LDAPS:=1636}

--- a/baseline/pingdirectoryproxy/pd.profile/dsconfig/20-external-server.dsconfig
+++ b/baseline/pingdirectoryproxy/pd.profile/dsconfig/20-external-server.dsconfig
@@ -5,6 +5,7 @@ dsconfig set-trust-manager-provider-prop \
 
 dsconfig create-external-server \
     --server-name pingdirectory  \
+    --type ping-identity-ds \
     --set server-host-name:${PD_ENGINE_PRIVATE_HOSTNAME}  \
     --set server-port:${PD_ENGINE_PRIVATE_PORT_LDAPS} \
     --set bind-dn:cn=pingdirectoryproxy  \

--- a/baseline/pingdirectoryproxy/pd.profile/dsconfig/20-external-server.dsconfig
+++ b/baseline/pingdirectoryproxy/pd.profile/dsconfig/20-external-server.dsconfig
@@ -1,8 +1,15 @@
+
+dsconfig set-trust-manager-provider-prop \
+    --provider-name 'Blind Trust'  \
+    --set enabled:true
+
 dsconfig create-external-server \
     --server-name pingdirectory  \
-    --type ping-identity-ds  \
-    --set server-host-name:pingdirectory  \
-    --set server-port:${LDAP_PORT} \
-    --set location:Docker  \
+    --set server-host-name:${PD_ENGINE_PRIVATE_HOSTNAME}  \
+    --set server-port:${PD_ENGINE_PRIVATE_PORT_LDAPS} \
     --set bind-dn:cn=pingdirectoryproxy  \
-    --set password<${ROOT_USER_PASSWORD_FILE}
+    --set password<${ROOT_USER_PASSWORD_FILE} \
+    --set location:${LOCATION}  \
+    --set connection-security:ssl \
+    --set key-manager-provider:Null \
+    --set 'trust-manager-provider:Blind Trust'


### PR DESCRIPTION
Users helm-chart variables to setup proper access to PingDirectory.

Also sets those variables in env-vars in the event that helm-charts are used to deploy.