### PR TITLE
Modify hook and env-vars to use correct service ports when talking to PingDirectory

### DIFF
--- a/simple-sync/pingdatasync/env_vars
+++ b/simple-sync/pingdatasync/env_vars
@@ -1,7 +1,7 @@
 # .suppress-container-warning
 #
 # NOTICE: Settings in this file will override values set at the
-#         image or orchestraton layers of the container.  Examples
+#         image or orchestration layers of the container.  Examples
 #         include variables that are specific to this server profile.
 #
 # Options include:
@@ -15,3 +15,4 @@
 #
 
 export PD_ENGINE_PRIVATE_HOSTNAME=${PD_ENGINE_PRIVATE_HOSTNAME:=pingdirectory}
+export PD_ENGINE_PRIVATE_PORT_LDAPS=${PD_ENGINE_PRIVATE_PORT_LDAPS:-$LDAPS_PORT}

--- a/simple-sync/pingdatasync/hooks/80-post-start.sh.post
+++ b/simple-sync/pingdatasync/hooks/80-post-start.sh.post
@@ -20,10 +20,10 @@ echo "PingDataSync - 127.0.0.1:${LDAPS_PORT} appears available"
 # Wait for PingDirectory before continuing
 #
 while true; do
-    echo "Waiting for PingDirectory - ${PD_ENGINE_PRIVATE_HOSTNAME}:${LDAPS_PORT}..."
-    wait-for "${PD_ENGINE_PRIVATE_HOSTNAME}:${LDAPS_PORT}" -q -t 30 && break
+    echo "Waiting for PingDirectory - ${PD_ENGINE_PRIVATE_HOSTNAME}:${PD_ENGINE_PRIVATE_PORT_LDAPS}..."
+    wait-for "${PD_ENGINE_PRIVATE_HOSTNAME}:${PD_ENGINE_PRIVATE_PORT_LDAPS}" -q -t 30 && break
 done
-echo "PingDirectory - ${PD_ENGINE_PRIVATE_HOSTNAME}:${LDAPS_PORT} appears available"
+echo "PingDirectory - ${PD_ENGINE_PRIVATE_HOSTNAME}:${PD_ENGINE_PRIVATE_PORT_LDAPS} appears available"
 sleep 2
 
 #


### PR DESCRIPTION
When the containers moved to unprivileged by default, this wasn't fixed to reflect the proper service port on the PingDirectory server.