### PR TITLE
Change LDAPS_PORT to PD_ENGINE_PRIVATE_PORT_LDAPS

### DIFF
--- a/simple-sync/pingdatasync/env_vars
+++ b/simple-sync/pingdatasync/env_vars
@@ -1,7 +1,7 @@
 # .suppress-container-warning
 #
 # NOTICE: Settings in this file will override values set at the
-#         image or orchestraton layers of the container.  Examples
+#         image or orchestration layers of the container.  Examples
 #         include variables that are specific to this server profile.
 #
 # Options include:
@@ -15,3 +15,4 @@
 #
 
 export PD_ENGINE_PRIVATE_HOSTNAME=${PD_ENGINE_PRIVATE_HOSTNAME:=pingdirectory}
+export PD_ENGINE_PRIVATE_PORT_LDAPS=${PD_ENGINE_PRIVATE_PORT_LDAPS:-$LDAPS_PORT}

--- a/simple-sync/pingdatasync/hooks/80-post-start.sh.post
+++ b/simple-sync/pingdatasync/hooks/80-post-start.sh.post
@@ -20,10 +20,10 @@ echo "PingDataSync - 127.0.0.1:${LDAPS_PORT} appears available"
 # Wait for PingDirectory before continuing
 #
 while true; do
-    echo "Waiting for PingDirectory - ${PD_ENGINE_PRIVATE_HOSTNAME}:${LDAPS_PORT}..."
-    wait-for "${PD_ENGINE_PRIVATE_HOSTNAME}:${LDAPS_PORT}" -q -t 30 && break
+    echo "Waiting for PingDirectory - ${PD_ENGINE_PRIVATE_HOSTNAME}:${PD_ENGINE_PRIVATE_PORT_LDAPS}..."
+    wait-for "${PD_ENGINE_PRIVATE_HOSTNAME}:${PD_ENGINE_PRIVATE_PORT_LDAPS}" -q -t 30 && break
 done
-echo "PingDirectory - ${PD_ENGINE_PRIVATE_HOSTNAME}:${LDAPS_PORT} appears available"
+echo "PingDirectory - ${PD_ENGINE_PRIVATE_HOSTNAME}:${PD_ENGINE_PRIVATE_PORT_LDAPS} appears available"
 sleep 2
 
 #

--- a/simple-sync/pingdatasync/pd.profile/dsconfig/20-sync-pipe-build.dsconfig.subst
+++ b/simple-sync/pingdatasync/pd.profile/dsconfig/20-sync-pipe-build.dsconfig.subst
@@ -10,7 +10,7 @@ dsconfig create-external-server \
     --server-name pingdirectory \
     --type ping-identity-ds \
 	--set server-host-name:${PD_ENGINE_PRIVATE_HOSTNAME} \
-    --set server-port:${LDAPS_PORT} \
+    --set server-port:${PD_ENGINE_PRIVATE_PORT_LDAPS} \
 	--set bind-dn:cn=sync \
     --set "password:AABkwRkIRfApR+R1uZPSciaUPmtEtTzjC/4=" \
     --set authorization-method:none \


### PR DESCRIPTION
With the recent changes to unprivileged containers, we need to make sure we change any LDAPS_PORTS to the proper variable representing the port on the service, which is often not the LDAPS_PORT