### PR TITLE
Add required config for PingAuthorize 8.3

### DIFF
--- a/baseline/pingauthorize/pd.profile/dsconfig/20-paz.dsconfig
+++ b/baseline/pingauthorize/pd.profile/dsconfig/20-paz.dsconfig
@@ -96,4 +96,5 @@ dsconfig create-gateway-api-endpoint \
 dsconfig set-policy-decision-service-prop \
    --set pdp-mode:embedded  \
    --set trust-framework-version:v1 \
-   --set "deployment-package<${SERVER_ROOT_DIR}/resource/simple.SDP"
+   --set "deployment-package<${SERVER_ROOT_DIR}/resource/simple.SDP" \
+   --set deployment-package-source-type:static-file

--- a/getting-started/pingauthorize/pd.profile/dsconfig/20-paz-config.dsconfig
+++ b/getting-started/pingauthorize/pd.profile/dsconfig/20-paz-config.dsconfig
@@ -1,4 +1,5 @@
 dsconfig set-policy-decision-service-prop \
   --set pdp-mode:embedded  \
   --set trust-framework-version:v2 \
-  --set "deployment-package<${SERVER_ROOT_DIR}/resource/simple.SDP"
+  --set "deployment-package<${SERVER_ROOT_DIR}/resource/simple.SDP" \
+  --set deployment-package-source-type:static-file


### PR DESCRIPTION
Update dsconfig for PingAuthorize server profiles to include the
required deployment-package-source-type configuration.