### PR TITLE
Dns propagation

### DIFF
--- a/baseline/pingdirectory/hooks/02-get-remote-server-profile.sh.post
+++ b/baseline/pingdirectory/hooks/02-get-remote-server-profile.sh.post
@@ -17,4 +17,4 @@ while test $count -lt 3 ; do
   fi
   sleep 2
 done 
-echo "INFO: successfully verified ${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX} matches pod ip"
+echo "INFO: successfully verified ${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX} matches pod ip - ${_localIp} "

--- a/baseline/pingdirectory/hooks/02-get-remote-server-profile.sh.post
+++ b/baseline/pingdirectory/hooks/02-get-remote-server-profile.sh.post
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+test -z "${K8S_POD_HOSTNAME_SUFFIX}" && exit 0
+echo "INFO: var K8S_POD_HOSTNAME_SUFFIX found, waiting for ${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX} dns propagation"
+_HOSTNAME="$(hostname)"
+count=0
+_localIp="$(hostname -i)"
+while test $count -lt 3 ; do
+  # get just ip address from route53
+  _remoteIp="$(getent ahosts "${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX}" | cut -d" " -f1 | sort -u)"
+  if test $? -eq 0 ; then
+    test "${_remoteIp}" = "${_localIp}" && count=$(( count+1 ))
+  else
+    count=0
+  fi
+  sleep 2
+done 
+echo "INFO: successfully verified ${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX} matches pod ip"

--- a/baseline/pingdirectory/hooks/02-get-remote-server-profile.sh.post
+++ b/baseline/pingdirectory/hooks/02-get-remote-server-profile.sh.post
@@ -8,7 +8,6 @@ _localIp="$(hostname -i)"
 echo "INFO: var K8S_POD_HOSTNAME_SUFFIX found, waiting for ${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX} dns propagation"
 count=0
 while test $count -lt 3 ; do
-  # get just ip address from route53
   _remoteIp="$(getent ahosts "${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX}" | cut -d" " -f1 | sort -u)"
   if test $? -eq 0 ; then
     test "${_remoteIp}" = "${_localIp}" && count=$(( count+1 ))

--- a/baseline/pingdirectory/hooks/02-get-remote-server-profile.sh.post
+++ b/baseline/pingdirectory/hooks/02-get-remote-server-profile.sh.post
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
 
+${VERBOSE} && set -x
+
 test -z "${K8S_POD_HOSTNAME_SUFFIX}" && exit 0
-echo "INFO: var K8S_POD_HOSTNAME_SUFFIX found, waiting for ${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX} dns propagation"
 _HOSTNAME="$(hostname)"
-count=0
 _localIp="$(hostname -i)"
+echo "INFO: var K8S_POD_HOSTNAME_SUFFIX found, waiting for ${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX} dns propagation"
+count=0
 while test $count -lt 3 ; do
   # get just ip address from route53
   _remoteIp="$(getent ahosts "${_HOSTNAME}${K8S_POD_HOSTNAME_SUFFIX}" | cut -d" " -f1 | sort -u)"


### PR DESCRIPTION
adding a hook: 
- useful for pd multi-region when dns is dynamically propagated (e.g. with ExternalDNS). 
- doesn't break anything if K8S_POD_HOSTNAME_SUFFIX is used without multi-cluster. 