### PR TITLE
Modify run.properties to support clustering

### DIFF
--- a/getting-started/pingaccess/instance/conf/run.properties.subst
+++ b/getting-started/pingaccess/instance/conf/run.properties.subst
@@ -19,7 +19,7 @@
 #                       - Configuration is queried from Console at startup.
 #
 
-pa.operational.mode=STANDALONE
+pa.operational.mode=${OPERATIONAL_MODE}
 
 #-------------------------------------------------------------------------------
 # Admin Properties


### PR DESCRIPTION
Add variable to operational mode to support clustering, relying on the environment variables to determine if CLUSTERED_CONSOLE, CLUSTERED_ENGINE, etc.