### PR TITLE
BRASS-734: Enable Password Policy State JSON in PingDirectory Server …

### DIFF
--- a/FIPS-integration/pingdirectory/pd.profile/dsconfig/10-virtual-attributes.dsconfig
+++ b/FIPS-integration/pingdirectory/pd.profile/dsconfig/10-virtual-attributes.dsconfig
@@ -1,0 +1,3 @@
+dsconfig set-virtual-attribute-prop \
+  --name "Password Policy State JSON" \
+  --set enabled:true

--- a/FIPS-integration/pingdirectory/pd.profile/ldif/userRoot/00-structure.ldif
+++ b/FIPS-integration/pingdirectory/pd.profile/ldif/userRoot/00-structure.ldif
@@ -9,6 +9,7 @@ aci: (targetattr="userPassword")(version 3.0; acl "Allow the pingfederate user t
 aci: (targetattr="isMemberOf")(version 3.0; acl "Allow the pingfederate user to get memberships"; allow (read) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 aci: (targetcontrol="1.3.6.1.4.1.42.2.27.9.5.8")(version 3.0; acl "Access to the Account Usability Control"; allow (read) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 aci: (targetcontrol="1.3.6.1.4.1.30221.2.5.40")(version 3.0; acl "Access to the Password Validation Details Request Control"; allow (read) userdn="ldap:///${USER_BASE_DN}";)
+aci: (targetattr="ds-pwp-state-json")(version 3.0; acl "Allow test user to read ds-pwp-state-json"; allow (read,search,compare) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 
 dn: ou=people,${USER_BASE_DN}
 aci: (targetattr="*")(version 3.0; acl "allow self-manage"; allow(all) userdn="ldap:///self";)

--- a/baseline/pingdirectory/pd.profile/dsconfig/10-virtual-attributes.dsconfig
+++ b/baseline/pingdirectory/pd.profile/dsconfig/10-virtual-attributes.dsconfig
@@ -1,0 +1,3 @@
+dsconfig set-virtual-attribute-prop \
+  --name "Password Policy State JSON" \
+  --set enabled:true

--- a/baseline/pingdirectory/pd.profile/ldif/userRoot/00-structure.ldif
+++ b/baseline/pingdirectory/pd.profile/ldif/userRoot/00-structure.ldif
@@ -9,6 +9,7 @@ aci: (targetattr="userPassword")(version 3.0; acl "Allow the pingfederate user t
 aci: (targetattr="isMemberOf")(version 3.0; acl "Allow the pingfederate user to get memberships"; allow (read) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 aci: (targetcontrol="1.3.6.1.4.1.42.2.27.9.5.8")(version 3.0; acl "Access to the Account Usability Control"; allow (read) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 aci: (targetcontrol="1.3.6.1.4.1.30221.2.5.40")(version 3.0; acl "Access to the Password Validation Details Request Control"; allow (read) userdn="ldap:///${USER_BASE_DN}";)
+aci: (targetattr="ds-pwp-state-json")(version 3.0; acl "Allow test user to read ds-pwp-state-json"; allow (read,search,compare) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 
 dn: ou=people,${USER_BASE_DN}
 aci: (targetattr="*")(version 3.0; acl "allow self-manage"; allow(all) userdn="ldap:///self";)

--- a/entry-balancing/pingdirectory/pd.profile/dsconfig/10-virtual-attributes.dsconfig
+++ b/entry-balancing/pingdirectory/pd.profile/dsconfig/10-virtual-attributes.dsconfig
@@ -1,0 +1,3 @@
+dsconfig set-virtual-attribute-prop \
+  --name "Password Policy State JSON" \
+  --set enabled:true

--- a/entry-balancing/pingdirectory/pd.profile/ldif/dataset/00-structure.ldif
+++ b/entry-balancing/pingdirectory/pd.profile/ldif/dataset/00-structure.ldif
@@ -8,6 +8,7 @@ aci: (targetcontrol="1.3.6.1.4.1.42.2.27.9.5.8")(version 3.0; acl "Access to the
 aci: (targetcontrol="1.3.6.1.4.1.30221.2.5.40")(version 3.0; acl "Access to the Password Validation Details Request Control"; allow (read) userdn="ldap:///ou=people,${USER_BASE_DN}";)
 aci: (targetattr="*")(version 3.0; acl "allow self-manage"; allow(all) userdn="ldap:///self";)
 aci: (targetAttr="*")(version 3.0; acl "admin rights"; allow(all) userdn="ldap:///uid=administrator,ou=People,${USER_BASE_DN}";)
+aci: (targetattr="ds-pwp-state-json")(version 3.0; acl "Allow test user to read ds-pwp-state-json"; allow (read,search,compare) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 objectClass: top
 objectClass: organizationalUnit
 ou: People

--- a/entry-balancing/pingdirectory/pd.profile/ldif/userRoot/00-structure.ldif
+++ b/entry-balancing/pingdirectory/pd.profile/ldif/userRoot/00-structure.ldif
@@ -9,6 +9,7 @@ aci: (targetattr="userPassword")(version 3.0; acl "Allow the pingfederate user t
 aci: (targetattr="isMemberOf")(version 3.0; acl "Allow the pingfederate user to get memberships"; allow (read) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 aci: (targetcontrol="1.3.6.1.4.1.42.2.27.9.5.8")(version 3.0; acl "Access to the Account Usability Control"; allow (read) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 aci: (targetcontrol="1.3.6.1.4.1.30221.2.5.40")(version 3.0; acl "Access to the Password Validation Details Request Control"; allow (read) userdn="ldap:///${USER_BASE_DN}";)
+aci: (targetattr="ds-pwp-state-json")(version 3.0; acl "Allow test user to read ds-pwp-state-json"; allow (read,search,compare) userdn="ldap:///cn=pingfederate,cn=root dns,cn=config";)
 
 dn: ou=groups,${USER_BASE_DN}
 aci: (targetAttr="*")(version 3.0; acl "admin rights"; allow(all) userdn="ldap:///uid=administrator,ou=People,${USER_BASE_DN}";)


### PR DESCRIPTION
…Profile

- Update all PingDirectory server profiles that are intended to interact with PingFederate.
- Add aci to allow pingfederate user to read the ds-pwp-state-json attribute to all 00-structure.ldif files of profiles affected.
- Add 10-virtual-attributes.dsconfig file to enable "Password Policy State JSON" in profiles affected.