### PR TITLE
Adding Failover Location to other PDP Cluster Location

### DIFF
--- a/pingdirectoryproxy-automatic-server-discovery/pingdirectoryproxy/pd.profile/dsconfig/discovery.dsconfig
+++ b/pingdirectoryproxy-automatic-server-discovery/pingdirectoryproxy/pd.profile/dsconfig/discovery.dsconfig
@@ -15,6 +15,14 @@ dsconfig create-ldap-health-check \
     --type replication-backlog \
     --set enabled:true \
     --set base-dn:dc=example,dc=com
+
+# Attempt to configure Locations using $Location = this location ; $PDP_LOC2 = secondary - preferred falover location.
+# Add 2ndary location - from ENV Var provided - could be derived from (K8S_CLUSTERS | replace  K8S_CLUSTER "")
+dsconfig create-location  \
+    --location-name "${PD_LOC2}"  --set "preferred-failover-location:${LOCATION}" 
+
+# current location - set failover to 2ndary just created
+dsconfig set-location-prop --location-name "${LOCATION}" --set "preferred-failover-location:${PD_LOC2}"      
  
 # Create an LDAP external server template with the above
 dsconfig create-ldap-external-server-template \


### PR DESCRIPTION
In order to provide location based PDP to PD assignment - with failover to 2nd Cluster - locations objects need to be configured with failover.

This dsconfig will require the 2nd Cluster name to be parsed into an ENV VAR - either via hook script, provided in deployment - or parsed in HELM chart from K8S_CLUSTERS - removing "this" cluster ? 