### PR TITLE
Remove PF-13-specific fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .idea
+
+scratch/

--- a/baseline/pingfederate/instance/bulk-config/data.json.subst
+++ b/baseline/pingfederate/instance/bulk-config/data.json.subst
@@ -291,15 +291,7 @@
         {
             "operationType": "SAVE",
             "items": [{
-                "staticJwksEnabled": false,
-                "publishDynamicKeyX5cs": false,
-                "dynamicKeyCertificateInformation": {
-                    "organization": null,
-                    "organizationUnit": null,
-                    "country": null,
-                    "state": null,
-                    "city": null
-                }
+                "staticJwksEnabled": false
             }],
             "resourceType": "/keyPairs/oauthOpenIdConnect"
         },


### PR DESCRIPTION
- missed in the first cleanup
- removed `publishDynamicKeyX5cs` and `dynamicKeyCertificateInformation` from `/keyPairs/oauthOpenIdConnect`

# Testing Results (2026-05-26)
| Image | Result |
|-------|--------|
| `pingidentity/pingfederate:12.3.0-latest` | PASS |
| `pingidentity/pingfederate:13.1.0-SNAPSHOT-fsoverride-alpine_3.23.3-al17-master-0623-arm64` | PASS |

Both containers completed `85-import-configuration.sh` without error.
